### PR TITLE
Add feature `rand` for compatibility with that ecosystem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = "1.74"
 
 [dependencies]
 getrandom = { version = "0.2", optional = true }
+rand_core = { version = "0.9", optional = true }
 
 [dev-dependencies]
 criterion = "0.5"
@@ -24,6 +25,7 @@ std = []
 tls = ["std"]
 unstable_tls = ["std"]
 unstable_simd = []
+rand = ["dep:rand_core"]
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The crate is `no_std` compatible.
                     thread local functions greatly. 
  * `unstable_simd` - Uses the unstable `std::simd` crate of Rust nightly to provide the SIMD version of the wide
                      generator.
+ * `rand`          - implements `RngCore` for compatibility with the `rand` ecosystem.
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,13 +63,13 @@
 //! The crate is `no_std` compatible.
 //!
 //!  * `std` - If `getrandom` is not used or returns an error, the generator will use the thread
-//!            name and the current instance time to create a seed value. Enabled by default.
+//!    name and the current instance time to create a seed value. Enabled by default.
 //!  * `tls` - Create static functions to use a thread local version of the generator. Enabled by default.
 //!  * `getrandom` - Uses the `getrandom` crate to create a seed of high randomness. Enabled by default.
 //!  * `unstable_tls` - Uses the unstable `thread_local` feature of Rust nightly. Improves the call
-//!                     times to the thread local functions greatly.
+//!    times to the thread local functions greatly.
 //!  * `unstable_simd` - Uses the unstable `std::simd` crate of Rust nightly to provide the SIMD
-//!                      version of the wide generator.
+//!    version of the wide generator.
 #![warn(missing_docs)]
 #![deny(clippy::unwrap_used)]
 #![cfg_attr(feature = "unstable_tls", feature(thread_local))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-// #[cfg(feature = "rand")]
+#[cfg(feature = "rand")]
 mod rand_compatibility;
 #[cfg(not(feature = "unstable_simd"))]
 mod stable_simd;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+// #[cfg(feature = "rand")]
+mod rand_compatibility;
 #[cfg(not(feature = "unstable_simd"))]
 mod stable_simd;
 #[cfg(all(feature = "tls", not(feature = "unstable_tls")))]

--- a/src/rand_compatibility.rs
+++ b/src/rand_compatibility.rs
@@ -1,0 +1,17 @@
+//! Implements traits from the `rand` crate to provide compatibility with the broader ecosystem.
+
+use crate::Rng;
+
+impl rand_core::RngCore for Rng {
+    fn next_u32(&mut self) -> u32 {
+        self.u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.u64()
+    }
+
+    fn fill_bytes(&mut self, dst: &mut [u8]) {
+        Rng::fill_bytes(self, dst)
+    }
+}

--- a/src/stable_simd/sse2.rs
+++ b/src/stable_simd/sse2.rs
@@ -66,19 +66,19 @@ impl RngWide {
         assert!(size_of::<[__m128i; 4]>() == size_of::<[[u64; 2]; 4]>());
         unsafe {
             Self {
-                x: transmute([
+                x: transmute::<[[u64; 2]; 4], [std::arch::x86_64::__m128i; 4]>([
                     [lane0[0], lane1[0]],
                     [lane2[0], lane3[0]],
                     [lane4[0], lane5[0]],
                     [lane6[0], lane7[0]],
                 ]),
-                y: transmute([
+                y: transmute::<[[u64; 2]; 4], [std::arch::x86_64::__m128i; 4]>([
                     [lane0[1], lane1[1]],
                     [lane2[1], lane3[1]],
                     [lane4[1], lane5[1]],
                     [lane6[1], lane7[1]],
                 ]),
-                z: transmute([
+                z: transmute::<[[u64; 2]; 4], [std::arch::x86_64::__m128i; 4]>([
                     [lane0[2], lane1[2]],
                     [lane2[2], lane3[2]],
                     [lane4[2], lane5[2]],
@@ -102,19 +102,19 @@ impl RngWide {
         assert!(size_of::<[__m128i; 4]>() == size_of::<[[u64; 2]; 4]>());
         unsafe {
             Self {
-                x: transmute([
+                x: transmute::<[[u64; 2]; 4], [std::arch::x86_64::__m128i; 4]>([
                     [seeds[0][0], seeds[1][0]],
                     [seeds[2][0], seeds[3][0]],
                     [seeds[4][0], seeds[5][0]],
                     [seeds[6][0], seeds[7][0]],
                 ]),
-                y: transmute([
+                y: transmute::<[[u64; 2]; 4], [std::arch::x86_64::__m128i; 4]>([
                     [seeds[0][1], seeds[1][1]],
                     [seeds[2][1], seeds[3][1]],
                     [seeds[4][1], seeds[5][1]],
                     [seeds[6][1], seeds[7][1]],
                 ]),
-                z: transmute([[
+                z: transmute::<[[[u64; 2]; 4]; 1], [std::arch::x86_64::__m128i; 4]>([[
                     [seeds[0][2], seeds[1][2]],
                     [seeds[2][2], seeds[3][2]],
                     [seeds[4][2], seeds[5][2]],
@@ -159,9 +159,9 @@ impl RngWide {
 
         assert!(size_of::<[__m128i; 4]>() == size_of::<[u64; 8]>());
         unsafe {
-            self.x = transmute(x);
-            self.y = transmute(y);
-            self.z = transmute(z);
+            self.x = transmute::<[u64; 8], [std::arch::x86_64::__m128i; 4]>(x);
+            self.y = transmute::<[u64; 8], [std::arch::x86_64::__m128i; 4]>(y);
+            self.z = transmute::<[u64; 8], [std::arch::x86_64::__m128i; 4]>(z);
         }
 
         self.seed_source = seed_source;


### PR DESCRIPTION
Moin.
I've been using this PRNG for a while because of its great performance so congratulations on this great crate.
This PR implements `rand_core::RngCore for Rng` to be able to use this PRNG in a context where `rand` ecosystem shines.
E.g it allows sampling from distributions in `rand::distr` and `rand_distr` like this:
```rust
let mut rng = romu::Rng::default();
let distr = rand_distr::Normal::new(T::zero(), T::one()).unwrap();
let val = distr.sample(&mut rng)
```

This is gated gated behind the `rand` feature flag. If you like this could be added to the default feature set as I'm sure this will come in handy for a lot of people.

P.S: It would be cool if (once accepted) you could publish this as version `0.7.1` on `crates.io`