### PR TITLE
Change return type of `RngWide::u64x8` to u64x8

### DIFF
--- a/src/unstable_simd.rs
+++ b/src/unstable_simd.rs
@@ -161,8 +161,8 @@ impl RngWide {
 
     /// Generates eight random u64 values.
     #[inline(always)]
-    pub fn u64x8(&mut self) -> [u64; 8] {
-        Simd::to_array(self.next())
+    pub fn u64x8(&mut self) -> u64x8 {
+        self.next()
     }
 
     /// Fills a mutable `[u8]` slice with random values.


### PR DESCRIPTION
## Changes include:
- Make `RngWide::next` in `unstable_simd.rs` public to get the SIMD type directly.
