### PR TITLE
Bump criterion, resolve warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ getrandom = { version = "0.3", optional = true }
 rand_core = { version = "0.9", optional = true }
 
 [dev-dependencies]
-criterion = "0.7"
+criterion = "0.8"
 
 [features]
 default = ["std", "tls", "getrandom"]

--- a/benches/random.rs
+++ b/benches/random.rs
@@ -1,4 +1,6 @@
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use romu::{Rng, RngWide};
 
 pub fn scalar(c: &mut Criterion) {


### PR DESCRIPTION
- bench: fix criterion deprecation warnings and use `std::hint::black_box` directly.
- bench: bump `criterion` version to `0.8`
