### PR TITLE
Benchmarks for `unstable_simd.rs` and an note in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,29 @@ bytes/RngWide/1048576   time:   [35.187 µs 35.266 µs 35.375 µs]
                         thrpt:  [27.606 GiB/s 27.691 GiB/s 27.754 GiB/s]
 ```
 
+AVX512 benchmark (AMD Ryzen 9 7950X) with `RUSTFLAGS=target-cpu=native` and `--features=unstable_simd`
+```
+bytes/RngWide/1048576   time:   [15.291 µs 15.304 µs 15.316 µs]
+                        thrpt:  [63.761 GiB/s 63.809 GiB/s 63.864 GiB/s]
+```
+
+## rustflags:
+To enable native CPU optimizations like AVX512, include the following in your `.cargo/config.toml` file:
+```toml
+[build]
+rustflags = ["-Ctarget-cpu=x86-64-v4"]
+```
+Or set it as an environment variable `RUSTFLAGS="-C target-cpu=x86-64-v4"`.
+
+You can query which `target-cpu` is supported with `/lib64/ld-linux-x86-64.so.2 --help`.
+- `x86-64-v3` (AVX2)
+- `x86-64-v4` (AVX512)
+
+This can improve SIMD enabled `RngWide` performance by up to 235% when the `unstable_simd` feature is enabled,
+leveraging AVX512 on supported platforms.
+But it can also lead to regression of various function, including `Rng::mod_usize` for example by 300%.
+Always benchmark your concrete implementation with `-Ctarget-cpu=x86-64-v4` flag enabled or disabled.
+
 ## Features
 
 The crate is `no_std` compatible.

--- a/README.md
+++ b/README.md
@@ -80,8 +80,12 @@ bytes/RngWide/1048576   time:   [35.187 µs 35.266 µs 35.375 µs]
 
 AVX512 benchmark (AMD Ryzen 9 7950X) with `RUSTFLAGS=target-cpu=native` and `--features=unstable_simd`
 ```
-bytes/RngWide/1048576   time:   [15.291 µs 15.304 µs 15.316 µs]
-                        thrpt:  [63.761 GiB/s 63.809 GiB/s 63.864 GiB/s]
+unstable_simd/u64x8/1024 time:   [921.92 ns 924.39 ns 926.89 ns]
+                        thrpt:  [8.8381 Gelem/s 8.8621 Gelem/s 8.8858 Gelem/s]
+                        thrpt:  [65.849 GiB/s 66.028 GiB/s 66.204 GiB/s]
+unstable_simd/fill_bytes/1048576
+                        time:   [15.197 µs 15.208 µs 15.219 µs]
+                        thrpt:  [64.167 GiB/s 64.216 GiB/s 64.262 GiB/s]
 ```
 
 ## rustflags:


### PR DESCRIPTION
- bench: add `unstable_simd` benches
- README: add section about `-Ctarget-cpu=native` and add AVX512 benchmarks.
- bench the `u64x8` method of `RngWide` in `unstable_simd.rs`