### PR TITLE
Improve performance of `RngWide::fill_bytes` in `unstable_simd.rs`

### DIFF
--- a/src/unstable_simd.rs
+++ b/src/unstable_simd.rs
@@ -185,3 +185,29 @@ impl RngWide {
             .for_each(|(i, x)| *x = data[i]);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unstable_simd_fill_bytes() {
+        let mut rng = RngWide::from_seed_with_64bit([0, 1, 2, 3, 4, 5, 6, 7]);
+
+        let mut buf = vec![0];
+        rng.fill_bytes(&mut buf);
+        assert_eq!(buf, vec![175]);
+
+        let mut buf = vec![0; 8];
+        rng.fill_bytes(&mut buf);
+        assert_eq!(buf, vec![37, 39, 185, 157, 84, 66, 204, 193]);
+
+        let mut buf = vec![0; 10];
+        rng.fill_bytes(&mut buf);
+        assert_eq!(buf, vec![204, 125, 231, 26, 243, 227, 70, 65, 94, 67]);
+
+        let mut buf = Vec::<u8>::new();
+        rng.fill_bytes(&mut buf);
+        assert_eq!(buf, Vec::new());
+    }
+}


### PR DESCRIPTION
This improves the performance of `RngWide::fill_bytes` in `unstable_simd.rs` by 3%, but introduces additional `unsafe` code, which may not be the best tradeoff.
I was hoping for more here TBH.

One upside with this implementations tail fill is that it does not generate another `u64x8` when no more bytes need to be filled.
The original impl would call `u64x8` even when the input slice was empty and no bytes were filled, which may be undesirable or unexpected.

Given that its only a 3% improvement on my hardware and it has additional unsafe, I'm totally fine with not merging these changes as well. Up to you

## Benchmark results:
with `RUSTFLAGS="-Ctarget-cpu=native" cargo bench --features=unstable_simd unstable_simd`

```shell
unstable_simd/fill_bytes/1048576
                        time:   [14.796 µs 14.806 µs 14.815 µs]
                        thrpt:  [65.917 GiB/s 65.958 GiB/s 66.000 GiB/s]
                 change:
                        time:   [−2.9259% −2.7899% −2.6762%] (p = 0.00 < 0.05)
                        thrpt:  [+2.7498% +2.8700% +3.0140%]
                        Performance has improved.
```